### PR TITLE
feat: Implement Exit-Intent Popup

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -5,12 +5,15 @@ import { WILDCARD_QUESTION, INITIAL_WILDCARDS } from './constants';
 import { useQuestionManager } from './hooks/useQuestionManager';
 import { useEnergyLevel } from './hooks/useEnergyLevel';
 import { useCustomQuestions } from './hooks/useCustomQuestions';
+import useExitIntent from './hooks/useExitIntent';
 import ModeSelectionScreen from './components/ModeSelectionScreen';
 import GameScreen from './components/GameScreen';
 import Confetti from './components/Confetti';
 import PlayerSetupScreen from './components/PlayerSetupScreen';
+import ExitIntentModal from './components/ExitIntentModal';
 
 const App: React.FC = () => {
+  const { showModal, setShowModal } = useExitIntent();
   const customQuestionsManager = useCustomQuestions();
   const questionManager = useQuestionManager(customQuestionsManager.customQuestions);
   const [gameState, setGameState] = useState<'mode-selection' | 'player-setup' | 'in-game'>('mode-selection');
@@ -155,6 +158,7 @@ const App: React.FC = () => {
   return (
     <div className="relative w-full h-screen overflow-hidden">
       {showConfetti && <Confetti />}
+      <ExitIntentModal show={showModal} onClose={() => setShowModal(false)} />
       <GameScreen
         key={selectedMode}
         gameMode={selectedMode}

--- a/components/ExitIntentModal.tsx
+++ b/components/ExitIntentModal.tsx
@@ -1,0 +1,41 @@
+import * as React from 'react';
+
+interface ExitIntentModalProps {
+  show: boolean;
+  onClose: () => void;
+}
+
+const ExitIntentModal: React.FC<ExitIntentModalProps> = ({ show, onClose }) => {
+  if (!show) {
+    return null;
+  }
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-60 backdrop-blur-sm flex items-center justify-center z-50 p-4">
+      <div className="bg-slate-800 border border-slate-700 rounded-2xl p-8 max-w-md w-full text-center shadow-lg transform transition-all duration-300 scale-100">
+        <h2 className="text-3xl font-bold text-white mb-3">Wait, don't go!</h2>
+        <p className="text-slate-300 mb-6">
+          Enjoying the game? Dig deeper with journaling to reflect and understand yourself.
+        </p>
+        <div className="flex flex-col sm:flex-row gap-4 justify-center">
+          <a
+            href="https://myjournalto.com/products/guided-journal"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="px-6 py-3 bg-pink-600 text-white font-semibold rounded-lg shadow-md hover:bg-pink-700 transition-all duration-300 transform hover:scale-105"
+          >
+            Discover Journaling
+          </a>
+          <button
+            onClick={onClose}
+            className="px-6 py-3 bg-slate-700 text-white font-semibold rounded-lg shadow-md hover:bg-slate-600 transition-colors"
+          >
+            Continue Playing
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ExitIntentModal; 

--- a/components/GameScreen.tsx
+++ b/components/GameScreen.tsx
@@ -1,5 +1,6 @@
 
-import React, { useState, useCallback } from 'react';
+import * as React from 'react';
+import { useState, useCallback } from 'react';
 import { GameMode, Player, Question, QuestionType, SessionConfig, SessionEnergy } from '../types';
 import Card from './Card';
 import PlayerDisplay from './PlayerDisplay';
@@ -32,7 +33,7 @@ const GameScreen: React.FC<GameScreenProps> = ({
   onUseWildcard,
   onReset,
   onEnergyOverride
-}) => {
+}: GameScreenProps) => {
   const [isFlipped, setIsFlipped] = useState(false);
   const [isAnimating, setIsAnimating] = useState(false);
   const [isInitialFlip, setIsInitialFlip] = useState(true);
@@ -64,14 +65,30 @@ const GameScreen: React.FC<GameScreenProps> = ({
   if (!question) {
     return (
       <div className="w-full h-screen flex flex-col items-center justify-center text-center p-4">
-        <h2 className="text-3xl font-bold text-white mb-4">You've finished all the cards!</h2>
-        <p className="text-slate-400 mb-8">Hope you learned something new.</p>
-        <button
-          onClick={onReset}
-          className="px-6 py-3 bg-pink-600 text-white font-semibold rounded-lg shadow-md hover:bg-pink-700 transition-colors"
-        >
-          Play Again
-        </button>
+        <div className="bg-slate-800/50 backdrop-blur-sm border border-slate-700 rounded-2xl p-8 max-w-md mx-auto">
+          <h2 className="text-3xl font-bold text-white mb-3">
+            Do you enjoy this game?
+          </h2>
+          <p className="text-slate-300 mb-6">
+            Dig deeper with journaling, a powerful tool to reflect and understand yourself.
+          </p>
+          <div className="flex flex-col sm:flex-row gap-4 justify-center">
+            <a
+              href="https://myjournalto.com/products/guided-journal"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="px-6 py-3 bg-pink-600 text-white font-semibold rounded-lg shadow-md hover:bg-pink-700 transition-all duration-300 transform hover:scale-105"
+            >
+              Try Journaling
+            </a>
+            <button
+              onClick={onReset}
+              className="px-6 py-3 bg-slate-700 text-white font-semibold rounded-lg shadow-md hover:bg-slate-600 transition-colors"
+            >
+              Play Again
+            </button>
+          </div>
+        </div>
       </div>
     );
   }

--- a/hooks/useExitIntent.ts
+++ b/hooks/useExitIntent.ts
@@ -1,0 +1,27 @@
+import { useState, useEffect } from 'react';
+
+const useExitIntent = () => {
+  const [showModal, setShowModal] = useState(false);
+
+  useEffect(() => {
+    const handleMouseLeave = (e: MouseEvent) => {
+      if (e.clientY <= 0) {
+        const alreadyShown = sessionStorage.getItem('exitIntentShown');
+        if (!alreadyShown) {
+          setShowModal(true);
+          sessionStorage.setItem('exitIntentShown', 'true');
+        }
+      }
+    };
+
+    document.addEventListener('mouseleave', handleMouseLeave);
+
+    return () => {
+      document.removeEventListener('mouseleave', handleMouseLeave);
+    };
+  }, []);
+
+  return { showModal, setShowModal };
+};
+
+export default useExitIntent; 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
       },
       "devDependencies": {
         "@types/node": "^22.14.0",
+        "@types/react": "^19.1.9",
         "autoprefixer": "^10.4.21",
         "postcss": "^8.5.6",
         "tailwindcss": "^3.4.17",
@@ -878,6 +879,16 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/react": {
+      "version": "19.1.9",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.9.tgz",
+      "integrity": "sha512-WmdoynAX8Stew/36uTSVMcLJJ1KRh6L3IZRx1PZ7qJtBqT3dYTgyDTx8H1qoRghErydW7xw9mSJ3wS//tCRpFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.0.2"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
@@ -1185,6 +1196,13 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/detect-libc": {
       "version": "2.0.4",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "devDependencies": {
     "@types/node": "^22.14.0",
+    "@types/react": "^19.1.9",
     "autoprefixer": "^10.4.21",
     "postcss": "^8.5.6",
     "tailwindcss": "^3.4.17",


### PR DESCRIPTION
This pull request introduces an exit-intent popup to promote the journaling business.

Key changes:
- Created a `useExitIntent` hook to detect when a user is about to leave the page.
- Added a new `ExitIntentModal` component to display the promotional message.
- Integrated the modal into `App.tsx` to be displayed once per session.
- Restored the original end-of-game promotional screen in `GameScreen.tsx` after feedback.

This feature aims to increase conversion by presenting a targeted offer at a key moment in the user journey.